### PR TITLE
docs: enforce Kustomize-only deployment policy and adapter naming

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -430,6 +430,8 @@ bootstrap          595443389404.dkr.ecr.us-west-2.amazonaws.com/magistrala:boots
 certs              595443389404.dkr.ecr.us-west-2.amazonaws.com/certs@sha256:f7a667508fc42f5104139bee5364f155f8ef8e4f6d01227f157cb05fef257536
 chirpstack         595443389404.dkr.ecr.us-west-2.amazonaws.com/chirpstack@sha256:0fef9e0b6ab71963f32f1a861bd05b80e0cbb063b92ef0410471066a30e0bbbe
 domains            595443389404.dkr.ecr.us-west-2.amazonaws.com/domains@sha256:f7a667508fc42f5104139bee5364f155f8ef8e4f6d01227f157cb05fef257536
+
+Deployment method finalized: Kustomize-only; Helm forbidden; enforced *-adapter naming and API paths (2025-10-06).
 http               595443389404.dkr.ecr.us-west-2.amazonaws.com/http-adapter@sha256:481e0789f954be2d4e3d27cbbfd81cd38c5c0fbdc4e965d72908fabe308bd8a0
 lora               595443389404.dkr.ecr.us-west-2.amazonaws.com/lora@sha256:DIGEST
 mqtt-adapter       595443389404.dkr.ecr.us-west-2.amazonaws.com/magistrala:mqtt-adapter-6ef9ab76ddc260750347cbeebe5614db703cfae9

--- a/reports/DEPLOYMENT_METHOD_KUSTOMIZE_ONLY.md
+++ b/reports/DEPLOYMENT_METHOD_KUSTOMIZE_ONLY.md
@@ -1,0 +1,86 @@
+# Deployment Method — Kustomize Only (Authoritative)
+
+## Non-negotiables
+- **Single method:** Kustomize (bases + overlays).
+- **Helm:** **Forbidden** (no charts/values/templates).
+- **Registry:** ECR-only; immutable SHA tags; deployments pin by **digest**.
+- **Namespace / Health / TLS:** `magistrala` / `/health` / `letsencrypt-prod` + `sbx-gobee-io-tls`.
+- **Adapters naming:** Only `http-adapter`, `lora-adapter`, `ws-adapter` (incl. API paths `/api/http-adapter`, `/api/lora-adapter`, `/api/ws-adapter`).
+
+## Canonical Repo Roles
+- **Source:** choovio/**gobee-source**
+- **Installer:** choovio/**gobee-platform-installer**
+- **Audit:** choovio/**gobee-audit**
+
+## Kustomize Layout (installer repo — reference)
+gobee-platform-installer/
+└─ k8s/
+   ├─ base/
+   │  ├─ namespace.yaml              # magistrala
+   │  ├─ certificate.yaml            # sbx-gobee-io-tls (letsencrypt-prod)
+   │  ├─ users-deploy.yaml           # image pinned by digest
+   │  ├─ things-deploy.yaml
+   │  ├─ certs-deploy.yaml
+   │  ├─ domains-deploy.yaml
+   │  ├─ bootstrap-deploy.yaml
+   │  ├─ provision-deploy.yaml
+   │  ├─ readers-deploy.yaml
+   │  ├─ reports-deploy.yaml
+   │  ├─ rules-deploy.yaml
+   │  ├─ http-adapter-deploy.yaml
+   │  ├─ lora-adapter-deploy.yaml
+   │  ├─ ws-adapter-deploy.yaml
+   │  └─ kustomization.yaml          # lists ALL base manifests only
+   └─ overlays/
+      └─ sbx/
+         ├─ ingress.yaml             # host sbx.gobee.io, /api/* rules (incl. /api/*-adapter)
+         ├─ replicas-patch.yaml
+         └─ kustomization.yaml       # resources: ["../../base", "./ingress.yaml", "./replicas-patch.yaml"]
+
+## k8s/base/kustomization.yaml (example)
+resources:
+  - namespace.yaml
+  - certificate.yaml
+  - users-deploy.yaml
+  - things-deploy.yaml
+  - certs-deploy.yaml
+  - domains-deploy.yaml
+  - bootstrap-deploy.yaml
+  - provision-deploy.yaml
+  - readers-deploy.yaml
+  - reports-deploy.yaml
+  - rules-deploy.yaml
+  - http-adapter-deploy.yaml
+  - lora-adapter-deploy.yaml
+  - ws-adapter-deploy.yaml
+
+## k8s/overlays/sbx/kustomization.yaml
+resources:
+  - ../../base
+  - ingress.yaml
+patches:
+  - path: replicas-patch.yaml
+
+## Deployment manifest — digest-pinned (users example)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: users
+  namespace: magistrala
+spec:
+  replicas: 2
+  selector: { matchLabels: { app: users } }
+  template:
+    metadata: { labels: { app: users } }
+    spec:
+      containers:
+        - name: users
+          image: "<ACC>.dkr.ecr.<REG>.amazonaws.com/gobee-users@sha256:<DIGEST>"
+          ports: [{ containerPort: 8080 }]
+          readinessProbe: { httpGet: { path: /health, port: 8080 } }
+          livenessProbe:  { httpGet: { path: /health, port: 8080 } }
+
+## Explicitly forbidden
+- Helm charts, values files, `helm template`, or Helm-managed releases.
+- Mutable tags (e.g., `latest`); `kustomize images:` rewrites that break digest pinning.
+- `/healthz` paths; any ingress outside `https://sbx.gobee.io/api/...`.

--- a/reports/IMAGE_POLICY_ECR_ONLY.md
+++ b/reports/IMAGE_POLICY_ECR_ONLY.md
@@ -12,17 +12,28 @@ SPDX-License-Identifier: Apache-2.0
 - **Namespace:** `magistrala`.
 - **Ingress base:** `https://sbx.gobee.io/api`.
 
+## Deployment Method
+- **Kustomize-only** (bases + overlays).
+- **Helm is forbidden** — no charts, values files, or Helm templating.
+- **Adapters must follow `*-adapter` naming** in manifests, API paths, ECR repos, and source directories.
+
 ## Tag & Digest Rules
 - **Tag schema:** `<git_short_sha>` (immutable). Optional suffix `-r<n>` if multiple builds from same SHA.
 - **Always pin deployments by digest** (sha256) in manifests/pins.
 - **No `latest`**—reject PRs that introduce floating tags.
 
+## Adapter Naming Standard
+- **Names:** `http-adapter`, `lora-adapter`, `ws-adapter`.
+- **API paths:** `/api/http-adapter`, `/api/lora-adapter`, `/api/ws-adapter`.
+- **ECR repos:** `…/gobee-http-adapter`, `…/gobee-lora-adapter`, `…/gobee-ws-adapter` (deploy by digest).
+- **Source directories:** `adapters/http-adapter`, `adapters/lora-adapter`, `adapters/ws-adapter`.
+
 ## Standard ECR Layout (examples)
-- `xxxxxxxxxxxx.dkr.ecr.<region>.amazonaws.com/magistrala-users`
-- `…/magistrala-things`, `…/magistrala-certs`, `…/magistrala-domains`
-- `…/magistrala-bootstrap`, `…/magistrala-provision`, `…/magistrala-readers`
-- `…/magistrala-reports`, `…/magistrala-rules`
-- `…/magistrala-http`, `…/magistrala-ws`
+- `xxxxxxxxxxxx.dkr.ecr.<region>.amazonaws.com/gobee-users`
+- `…/gobee-things`, `…/gobee-certs`, `…/gobee-domains`
+- `…/gobee-bootstrap`, `…/gobee-provision`, `…/gobee-readers`
+- `…/gobee-reports`, `…/gobee-rules`
+- `…/gobee-http-adapter`, `…/gobee-lora-adapter`, `…/gobee-ws-adapter`
 
 ## Build Inputs (per service)
 - **Context:** `choovio/magistrala-fork/<service path>`
@@ -42,7 +53,7 @@ $ACC = "xxxxxxxxxxxx"
 $ECR = "$ACC.dkr.ecr.$REG.amazonaws.com"
 
 # Build & tag (example: users)
-$IMG = "$ECR/magistrala-users:$SHA"
+$IMG = "$ECR/gobee-users:$SHA"
 docker build -t $IMG .\services\users
 docker push $IMG
 

--- a/reports/MANIFEST_PINNING_TEMPLATE.md
+++ b/reports/MANIFEST_PINNING_TEMPLATE.md
@@ -1,0 +1,73 @@
+# MANIFEST PINNING TEMPLATE — Digest-Only Deployments
+
+Use this template whenever adding or updating Kubernetes manifests or pins. All deployments are managed with **Kustomize-only** workflows and must be digest pinned.
+
+## Kustomize Base (example)
+```yaml
+resources:
+  - namespace.yaml
+  - certificate.yaml
+  - users-deploy.yaml
+  - things-deploy.yaml
+  - certs-deploy.yaml
+  - domains-deploy.yaml
+  - bootstrap-deploy.yaml
+  - provision-deploy.yaml
+  - readers-deploy.yaml
+  - reports-deploy.yaml
+  - rules-deploy.yaml
+  - http-adapter-deploy.yaml
+  - lora-adapter-deploy.yaml
+  - ws-adapter-deploy.yaml
+```
+
+## Kustomize Overlay (example)
+```yaml
+resources:
+  - ../../base
+  - ingress.yaml
+patches:
+  - path: replicas-patch.yaml
+```
+
+**Do not use Helm in this project.**
+
+**Adapters must use `*-adapter` naming across manifests and API paths.**
+
+## Deployment Manifest (digest pinned example)
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: users
+  namespace: magistrala
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: users
+  template:
+    metadata:
+      labels:
+        app: users
+    spec:
+      containers:
+        - name: users
+          image: "<ACC>.dkr.ecr.<REG>.amazonaws.com/gobee-users@sha256:<DIGEST>"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+```
+
+## Pinning Rules
+- Always commit manifests with ECR digests (`@sha256:`).
+- Never rely on mutable tags or `kustomize images:` rewrites.
+- Namespace stays `magistrala`; health probes point at `/health` only.
+- Ingress routes live under `https://sbx.gobee.io/api/...` including `/api/http-adapter`, `/api/lora-adapter`, `/api/ws-adapter`.

--- a/reports/SERVICE_MATRIX.md
+++ b/reports/SERVICE_MATRIX.md
@@ -2,19 +2,20 @@
 
 > Use this table during (and after) the rebuild to pin exact artifacts. Fill the columns as you build/push/deploy. Keep rows ordered as below.
 
-| Service         | Path Prefix      | Health Path | Source Dir (magistrala-fork) | **ECR Repo URI**                 | Image Tag (immutable) | Digest (sha256:...) | Last Build SHA | Last Deployed (UTC) |
-|-----------------|------------------|-------------|-------------------------------|-------------------------------|-----------------------|---------------------|----------------|---------------------|
-| users           | /api/users       | /health     | services/users                | ecr://…/magistrala-users      | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| things          | /api/things      | /health     | services/things               | ecr://…/magistrala-things     | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| certs           | /api/certs       | /health     | services/certs                | ecr://…/magistrala-certs      | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| domains         | /api/domains     | /health     | services/domains              | ecr://…/magistrala-domains    | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| bootstrap       | /api/bootstrap   | /health     | services/bootstrap            | ecr://…/magistrala-bootstrap  | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| provision       | /api/provision   | /health     | services/provision            | ecr://…/magistrala-provision  | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| readers         | /api/readers     | /health     | services/readers              | ecr://…/magistrala-readers    | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| reports         | /api/reports     | /health     | services/reports              | ecr://…/magistrala-reports    | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| rules           | /api/rules       | /health     | services/rules                | ecr://…/magistrala-rules      | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| http-adapter    | /api/http        | /health     | adapters/http                 | ecr://…/magistrala-http       | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
-| ws-adapter      | /api/ws          | /health     | adapters/ws                   | ecr://…/magistrala-ws         | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| Service         | Path Prefix        | Health Path | Source Dir (magistrala-fork) | **ECR Repo URI**              | Image Tag (immutable) | Digest (sha256:...) | Last Build SHA | Last Deployed (UTC) |
+|-----------------|--------------------|-------------|-------------------------------|-------------------------------|-----------------------|---------------------|----------------|---------------------|
+| users           | /api/users         | /health     | services/users                | ecr://…/gobee-users           | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| things          | /api/things        | /health     | services/things               | ecr://…/gobee-things          | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| certs           | /api/certs         | /health     | services/certs                | ecr://…/gobee-certs           | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| domains         | /api/domains       | /health     | services/domains              | ecr://…/gobee-domains         | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| bootstrap       | /api/bootstrap     | /health     | services/bootstrap            | ecr://…/gobee-bootstrap       | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| provision       | /api/provision     | /health     | services/provision            | ecr://…/gobee-provision       | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| readers         | /api/readers       | /health     | services/readers              | ecr://…/gobee-readers         | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| reports         | /api/reports       | /health     | services/reports              | ecr://…/gobee-reports         | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| rules           | /api/rules         | /health     | services/rules                | ecr://…/gobee-rules           | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| http-adapter    | /api/http-adapter  | /health     | adapters/http-adapter         | ecr://…/gobee-http-adapter    | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| lora-adapter    | /api/lora-adapter  | /health     | adapters/lora-adapter         | ecr://…/gobee-lora-adapter    | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
+| ws-adapter      | /api/ws-adapter    | /health     | adapters/ws-adapter           | ecr://…/gobee-ws-adapter      | <to fill>             | <to fill>           | <to fill>       | <to fill>          |
 
 **Notes**
 - Health path unified to `/health`.

--- a/reports/redeploy-readiness-2025-10-06.md
+++ b/reports/redeploy-readiness-2025-10-06.md
@@ -8,6 +8,8 @@ This document is the single, canonical pre-flight checklist for a **clean redepl
 - Namespace: `magistrala`
 - Health path: `/health` (not `/healthz`)
 - TLS: `ClusterIssuer=letsencrypt-prod`, `Secret=sbx-gobee-io-tls`
+- Deployment method: **Kustomize-only** (Helm forbidden).
+- Adapter naming: only `http-adapter`, `lora-adapter`, `ws-adapter`; API paths `/api/http-adapter`, `/api/lora-adapter`, `/api/ws-adapter`.
 - SPDX header required with CHOOVIO copyright
 
 ## Repos & Roles


### PR DESCRIPTION
## Summary
- add an authoritative Kustomize-only deployment policy and refreshed manifest pinning template
- update image policy, service matrix, and readiness checklist to ban Helm and require http/lora/ws adapter naming everywhere
- log the deployment-method decision in STATUS.md and align adapter entries with canonical API and ECR paths

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68e46ffb779c832b8a425d7be4c6d297