### PR TITLE
chore(audit): add ChirpStack SBX status (lns.gobee.io) + SBX backend deploy playbook; extend STATUS.md; seed snapshot template

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -50,6 +50,7 @@
 - [ ] ChirpStack console screenshot stored (SBX credentials)
 - [ ] LoRa test uplink proves SBX ingestion
 - [ ] Magistrala namespace events saved for adapter pods
+- [ ] Test devices removed or reset after validation
 - Reference: `docs/CHIRPSTACK_STATUS.md`
 
 ## SBX Backend Deploy Readiness
@@ -59,6 +60,7 @@
 - [ ] Image digests pinned before `kubectl apply`
 - [ ] Post-deploy verification + smoke tests logged
 - [ ] Snapshot `RESULTS.md` completed using template
+- [ ] Evidence stored in current snapshot folder with `BEGIN/END RESULTS` block
 - Reference: `docs/SBX_BACKEND_DEPLOY_PLAYBOOK.md`
 
 ---

--- a/docs/CHIRPSTACK_STATUS.md
+++ b/docs/CHIRPSTACK_STATUS.md
@@ -1,11 +1,13 @@
 # ChirpStack Status — SBX (lns.gobee.io)
 
-The SBX sandbox uses a **test-only** ChirpStack deployment to validate LoRaWAN packet delivery without touching production infrastructure.
+The SBX sandbox keeps a **slim, test-only** ChirpStack deployment that exists purely to validate LoRaWAN packet delivery without
+touching production infrastructure. Treat it as disposable and refresh evidence on every audit run.
 
 - **Host:** `lns.gobee.io`
 - **Role:** Proof-of-life for LoRa adapters and device routing tests only
 - **Scope:** SBX sandbox; no production traffic or credentials
 - **Data retention:** Ephemeral (cleared between audit snapshots)
+- **Tenancy:** Single-tenant test space; remove devices after validation
 
 ## Readiness checklist
 
@@ -14,6 +16,7 @@ The SBX sandbox uses a **test-only** ChirpStack deployment to validate LoRaWAN p
 - [ ] ChirpStack console reachable with SBX-only credentials (stored in vault)
 - [ ] LoRa packet forwarder points to `lns.gobee.io` over TLS
 - [ ] Events appear in SBX magistrala namespace (test tenants/devices only)
+- [ ] Evidence stored under current snapshot folder
 
 ## Evidence to capture per audit
 

--- a/docs/SBX_BACKEND_DEPLOY_PLAYBOOK.md
+++ b/docs/SBX_BACKEND_DEPLOY_PLAYBOOK.md
@@ -1,12 +1,14 @@
 # SBX Backend Deploy Playbook (Windows PowerShell)
 
-This playbook covers the SBX magistrala namespace deployment using PowerShell 7 on Windows. Follow the **verify-first** principle: capture evidence before and after every action. API base paths remain `/api/*`; skip ChirpStack unless you are testing the LoRa adapter.
+Use this flow to deploy SBX backend workloads into the `magistrala` namespace from a Windows 11 workstation running PowerShell 7.
+Follow the **verify-first** rule: gather baseline evidence before changing anything, deploy with `/api/*` paths intact, and skip
+ChirpStack unless you are explicitly exercising the LoRa adapter.
 
 ## Prerequisites
 
 - Windows 11 workstation with PowerShell 7.4+
 - AWS CLI v2 with SBX profile configured (`aws sts get-caller-identity` must resolve)
-- kubectl pointing to SBX EKS cluster
+- `kubectl` pointing to SBX EKS cluster
 - Access to AWS ECR (login via `aws ecr get-login-password`)
 - Latest gobee-platform-installer repo checkout (sbx branch or tag)
 

--- a/snapshots/TEMPLATE/RESULTS.md
+++ b/snapshots/TEMPLATE/RESULTS.md
@@ -18,4 +18,5 @@ Rules:
 - Keep values concise and verifiable.
 - Replace placeholders; remove unused sections rather than leaving them blank.
 - If rollback executed, include both deploy and rollback evidence bullets.
+- Store supporting logs (kubectl, transcripts, screenshots) alongside the snapshot folder.
 - Do not include command transcripts outside the block; store logs under the snapshot folder.


### PR DESCRIPTION
## Summary
- expand the ChirpStack SBX status guide with tenancy guidance, required evidence, and snapshot handling reminders
- refresh the SBX backend deploy playbook to stress verify-first PowerShell flow and `/api/*` contract details
- extend STATUS and the snapshot RESULTS template with new checklist items for audit evidence retention

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68e5453d7c74832b8eb9a8b6da5c2b22