### PR TITLE
guard(audit): harden anti-drift checks + finalize gobee/MQTT policy; block legacy patterns

### DIFF
--- a/.github/workflows/audit-guards.yml
+++ b/.github/workflows/audit-guards.yml
@@ -1,0 +1,77 @@
+# Copyright (c) CHOOVIO Inc.
+# SPDX-License-Identifier: Apache-2.0
+name: audit-guards
+on:
+  pull_request:
+    paths:
+      - '**/*.yaml'
+      - '**/*.yml'
+      - '**/*.ps1'
+      - 'k8s/**'
+      - 'pins/**'
+jobs:
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 1) Canonical endpoints & namespace
+      - name: Block legacy endpoints and namespace
+        shell: bash
+        run: |
+          set -euo pipefail
+          ! git grep -nE 'sbx\.api\.gobee\.io' -- '**/*' ':!**/*.md' || (echo "Use https://sbx.gobee.io + base /api"; exit 1)
+          ! git grep -nE '/api/sbx'            -- '**/*' ':!**/*.md' || (echo "Use base path /api only"; exit 1)
+          ! git grep -nE '/api/api'            -- '**/*' ':!**/*.md' || (echo "Double /api detected"; exit 1)
+          ! git grep -nE '\bmagistrala\b'      -- '**/*.y*ml' ':!**/*.md' || (echo "Namespace must be gobee"; exit 1)
+
+      # 2) Health endpoint uniformity
+      - name: Block /healthz
+        shell: bash
+        run: |
+          set -euo pipefail
+          ! git grep -nE '/healthz' -- '**/*' ':!**/*.md' || (echo "Use /health (not /healthz)"; exit 1)
+
+      # 3) Image pinning & naming rules (k8s only if exists)
+      - name: Enforce digest pins and service naming
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-files 'k8s/**' >/dev/null 2>&1; then
+            ! git grep -nE 'image:\s+[^@]+:[^[:space:]]+$' k8s || (echo "Floating image tag in k8s/ (must use @sha256:digest)"; exit 1)
+            ! git grep -nE '\bname:\s*.+-svc\b' k8s || (echo "K8s resource names must not end with -svc"; exit 1)
+          fi
+
+      # 4) Tooling discipline (PowerShell-only scripts, no jq/rg in PS)
+      - name: Forbid jq/rg use inside PowerShell scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-files '**/*.ps1' >/dev/null 2>&1; then
+            ! git grep -nE '\bjq\b' '**/*.ps1' || (echo "Do not use jq in PowerShell scripts"; exit 1)
+            ! git grep -nE '\brg\b' '**/*.ps1' || (echo "Do not use ripgrep (rg) in PowerShell scripts"; exit 1)
+          fi
+
+      # 5) SPDX headers in PS1 and YAML
+      - name: Enforce SPDX headers
+        shell: bash
+        run: |
+          set -euo pipefail
+          check_spdx () {
+            local pat="$1"; shift
+            while IFS= read -r f; do
+              head -n 5 "$f" | grep -q 'SPDX-License-Identifier:' || { echo "SPDX header missing: $f"; exit 1; }
+            done < <(git ls-files $pat || true)
+          }
+          check_spdx '**/*.ps1'
+          check_spdx '**/*.yml'
+          check_spdx '**/*.yaml'
+
+      # 6) Pins live only in audit repo (policy check)
+      - name: Prevent stray pin files outside /pins
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-files '**/*pins*.*' ':!pins/**' ':!**/*.md' | grep .; then
+            echo "Pin files must live only under /pins in this repo"; exit 1
+          fi

--- a/STATUS.md
+++ b/STATUS.md
@@ -453,6 +453,17 @@ chirpstack         595443389404.dkr.ecr.us-west-2.amazonaws.com/chirpstack@sha25
 domains            595443389404.dkr.ecr.us-west-2.amazonaws.com/domains@sha256:f7a667508fc42f5104139bee5364f155f8ef8e4f6d01227f157cb05fef257536
 
 Deployment method finalized: Kustomize-only; Helm forbidden; enforced *-adapter naming and API paths (2025-10-06).
+
+## Anti-Drift Guards (must be GREEN before fresh deployment)
+- [ ] CI guard present: `.github/workflows/audit-guards.yml`
+- [ ] Namespace policy in docs: `gobee`; no references to `magistrala`
+- [ ] Endpoint policy in docs: origin `https://sbx.gobee.io`, base `/api`, health `/health`
+- [ ] CI blocks: `sbx.api.gobee.io`, `/api/sbx`, `/api/api`, `/healthz`
+- [ ] CI enforces k8s: no floating image tags, no `-svc` resource names (if `k8s/` exists)
+- [ ] Pins policy documented; no stray pin files
+- [ ] Tooling policy documented; CI forbids `jq`/`rg` in PS
+- [ ] SPDX headers enforced in `.ps1` and YAML
+- [ ] ChirpStack SBX policy documented (MQTT, `lns.gobee.io`)
 http               595443389404.dkr.ecr.us-west-2.amazonaws.com/http-adapter@sha256:481e0789f954be2d4e3d27cbbfd81cd38c5c0fbdc4e965d72908fabe308bd8a0
 lora               595443389404.dkr.ecr.us-west-2.amazonaws.com/lora@sha256:DIGEST
 mqtt-adapter       595443389404.dkr.ecr.us-west-2.amazonaws.com/magistrala:mqtt-adapter-6ef9ab76ddc260750347cbeebe5614db703cfae9

--- a/docs/IMAGE_AND_PINS_POLICY.md
+++ b/docs/IMAGE_AND_PINS_POLICY.md
@@ -1,0 +1,7 @@
+# Image & Pins Policy
+Copyright (c) CHOOVIO Inc.
+SPDX-License-Identifier: Apache-2.0
+
+- **Registry:** Choovio ECR images only for deploys.
+- **Pinning:** Use immutable digests `repo@sha256:<digest>`; **no tags** in k8s manifests.
+- **Location of pins:** `/pins` in this `gobee-audit` repo is the **only** authoritative place. Do not duplicate pins elsewhere.

--- a/docs/NAMESPACE_AND_ENDPOINT_POLICY.md
+++ b/docs/NAMESPACE_AND_ENDPOINT_POLICY.md
@@ -1,0 +1,8 @@
+# Canonical Namespace & Endpoint Policy
+Copyright (c) CHOOVIO Inc.
+SPDX-License-Identifier: Apache-2.0
+
+- **Namespace:** `gobee` (fresh deployments). Do not use `magistrala`.
+- **Origin:** `https://sbx.gobee.io`
+- **API base path:** `/api` only (no `/api/sbx`, no `/v1`, no double `/api/api`).
+- **Health endpoint:** `/health` only.

--- a/docs/TOOLING_POLICY.md
+++ b/docs/TOOLING_POLICY.md
@@ -1,0 +1,7 @@
+# Tooling Policy (Ops Scripts)
+Copyright (c) CHOOVIO Inc.
+SPDX-License-Identifier: Apache-2.0
+
+- Windows **PowerShell** only for operational scripts in this repo.
+- Do not rely on external CLI tools like `jq` or `rg` inside PS scripts.
+- SPDX header required at the top of `.ps1`, `.yaml`, `.yml`.


### PR DESCRIPTION
## Summary
- add audit-guards workflow to enforce canonical endpoints, namespace, pins location, SPDX headers, and tooling rules
- document namespace/endpoint, image/pins, and tooling policies to align with the new CI guardrails
- extend STATUS.md with anti-drift checklist items covering gobee namespace, MQTT policy, and CI protections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e55292e624832b8442afa457d6d2a7