### PR TITLE
chore: add Codex and PowerShell task templates

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -464,6 +464,7 @@ Deployment method finalized: Kustomize-only; Helm forbidden; enforced *-adapter 
 - [ ] Tooling policy documented; CI forbids `jq`/`rg` in PS
 - [ ] SPDX headers enforced in `.ps1` and YAML
 - [ ] ChirpStack SBX policy documented (MQTT, `lns.gobee.io`)
+- 2025-10-07: Added PS & Codex task templates. See docs/templates/.
 http               595443389404.dkr.ecr.us-west-2.amazonaws.com/http-adapter@sha256:481e0789f954be2d4e3d27cbbfd81cd38c5c0fbdc4e965d72908fabe308bd8a0
 lora               595443389404.dkr.ecr.us-west-2.amazonaws.com/lora@sha256:DIGEST
 mqtt-adapter       595443389404.dkr.ecr.us-west-2.amazonaws.com/magistrala:mqtt-adapter-6ef9ab76ddc260750347cbeebe5614db703cfae9

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,16 @@
+Task Templates
+powershell-task-template.ps1 — Standard PS task with clean RESULTS block.
+
+codex-ask-template.md — Zero-side-effect request template.
+
+codex-code-template.md — Idempotent code task with PR + RESULTS.
+
+RESULTS Block Rules
+
+Header: ==== RESULTS BEGIN (COPY/PASTE) ====
+
+Footer: ==== RESULTS END (COPY/PASTE) ====
+
+Print once (PS: here-string; Bash: echo block)
+
+No $Host in PS; always set working dir at top.

--- a/docs/templates/codex-ask-template.md
+++ b/docs/templates/codex-ask-template.md
@@ -1,0 +1,18 @@
+# Codex Task — <TITLE>
+**Type:** Codex Ask  
+**Environment/Repo:** <org/repo or env>
+
+## Goal
+<What you need from the user or external source; no repo writes.>
+
+## Provide Back
+- Exact facts / decisions requested
+- Any blockers or missing info
+- Next single step (optional)
+
+## Notes
+- No side effects; no writes.
+- Be concise. No walls of text.
+
+## Expected Paste-Back
+A short confirmation, or the info requested.

--- a/docs/templates/codex-code-template.md
+++ b/docs/templates/codex-code-template.md
@@ -1,0 +1,43 @@
+# Codex Task — <TITLE>
+**Type:** Codex Code  
+**Environment/Repo:** <org/repo>
+
+## What this does
+<One sentence describing code-side effects.>
+
+## Script (idempotent)
+```bash
+set -euo pipefail
+
+# 0) Repo root
+cd "<local path to repo>"
+
+git fetch --all --prune
+git checkout main
+git pull --ff-only
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BRANCH="chore/<slug>-$STAMP"
+git checkout -b "$BRANCH"
+
+# 1) Do work
+# <commands>
+
+# 2) Commit & push
+git add -A
+git commit -m "<commit message> [$STAMP]"
+git push --set-upstream origin "$BRANCH"
+
+# 3) RESULTS tail block (copy/paste)
+echo "==== RESULTS BEGIN (COPY/PASTE) ===="
+echo "Repo: <org/repo>"
+echo "Branch: $BRANCH"
+echo "PR: https://github.com/<org/repo>/compare/main...$BRANCH?expand=1"
+echo "==== RESULTS END (COPY/PASTE) ===="
+Review checklist
+Minimal diff, clear message
+
+Single purpose
+
+No unrelated churn
+```

--- a/docs/templates/powershell-task-template.ps1
+++ b/docs/templates/powershell-task-template.ps1
@@ -1,0 +1,26 @@
+# PowerShell Task Template
+# Usage: Replace <WORKDIR> and task body. Keep RESULTS block as-is.
+
+# 1) Set working directory (ALWAYS)
+Set-Location "<WORKDIR>"
+
+# 2) Task body (collect output in variables)
+# $out = "example output"
+
+# 3) RESULTS (single here-string, printed once; orange via DarkYellow)
+function Show-Results {
+  param([string]$Body)
+  $HEADER = "==== RESULTS BEGIN (COPY/PASTE) ===="
+  $FOOTER = "==== RESULTS END (COPY/PASTE) ===="
+  Write-Host $HEADER -ForegroundColor DarkYellow
+  Write-Host $Body   -ForegroundColor DarkYellow
+  Write-Host $FOOTER -ForegroundColor DarkYellow
+}
+
+# Example:
+# $body = @"
+# Summary: <what was done>
+# Details:
+# $out
+# "@
+# Show-Results -Body $body


### PR DESCRIPTION
## Summary
- add reusable Codex Ask, Codex Code, and PowerShell task templates under docs/templates
- document template usage and RESULTS rules in docs/templates/README.md
- log the new templates in STATUS.md for visibility

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_b_68e557f71a04832b97be849cb763a2b6