### PR TITLE
Add SBX core build checkpoint documentation

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -10,6 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 ## Current Status
 
 ### Backend — Source & Registry
+- 2025-10-07 PT: Core batch built & digests pinned to SBX overlay (no apply). Parser standardized (YAML-first, regex fallback).
 - 2025-10-07 PT: Source completeness GREEN (overlay + contrib). Mirror CI disabled. All required ECR repos created (immutable, scanOnPush, lifecycle 20).
 
 ## Canonical Truth

--- a/reports/checkpoints/2025-10-07-core-build-and-pin.md
+++ b/reports/checkpoints/2025-10-07-core-build-and-pin.md
@@ -1,0 +1,21 @@
+# Checkpoint — Core build & digest pin (SBX) (2025-10-07 PT)
+
+## What we did
+- Parsed `batches/sbx-batches.yaml` with a proper YAML parser (fallback kept for PS without module).
+- Built from **centralized Dockerfile** targets and pushed to **immutable** ECR repos.
+- Wrote **digest-only** pins to `gobee-installer/k8s/overlays/sbx/kustomization.yaml` (no apply).
+
+## Core services covered
+users, things, certs, domains, bootstrap, provision
+
+## Guardrails reaffirmed
+- Kustomize-only (no Helm).
+- Digest-only pinning; no mutable tags.
+- One action per reply; verify-first; PC↔GitHub sync after every commit.
+- EKS: **wait** until all 18 services are built & pinned.
+
+## Notes for next batches
+- Prefer **ConvertFrom-Yaml**; if unavailable, use the indent-aware parser.
+- Keep batch definitions in `batches/sbx-batches.yaml` as the single source of truth.
+
+_(This is documentation-only; no cluster changes.)_


### PR DESCRIPTION
## Summary
- add a checkpoint report documenting the 2025-10-07 core build and digest pin activity for SBX
- note in STATUS that the SBX overlay now has digest pins and the parser approach is standardized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5cff10738832bbb724d529c5884de